### PR TITLE
add support for Lucene search index analyzers

### DIFF
--- a/Sources/CouchDesignDocuments/AnalyzerDictionary.cs
+++ b/Sources/CouchDesignDocuments/AnalyzerDictionary.cs
@@ -1,0 +1,29 @@
+﻿namespace TheDmi.CouchDesignDocuments
+{
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+
+    // The default JSON serialization configured for use in CouchDesignDocuments converts keys to snake_case,
+    // but certain keys in analyzer dictionaries correspond to user-defined index names (i.e. the keys in the
+    // "fields" dictionary used in conjunction with the "perfield" analyzer) and can therefore have
+    // any type of capitalization, which must be preserved upon JSON serialization. To ensure this preservation,
+    // this custom dictionary implementation is defined, so that the default key serialization won't be applied
+    // to the dictionary defining the analyzer configuration.
+    //
+    // Note: overriding the default serialization via a C# attribute defined for the `Analyzer` value doesn't
+    // appear to be possible:
+    // * the use of `ContractResolver.ResolvePropertyName` in the custom contract resolver in
+    //     `DesignDocumentSerializerSettings` overrides the `JsonPropertyAttribute` property name
+    //     see https://github.com/JamesNK/Newtonsoft.Json/issues/1463
+    // * replacing the `ResolvePropertyName` with a `NamingStrategy` as suggested in the issue above doesn't
+    //     solve the problem in a satisfactory manner either, due not being applied to the nested dictionaries
+    //     present in an analyzer configuration value (the "fields" sub-dictionary in the "perfield" analyzer
+    //     case)
+    //     see https://github.com/JamesNK/Newtonsoft.Json/issues/2201
+    [JsonDictionary(NamingStrategyType = typeof(DefaultNamingStrategy))]
+    public class AnalyzerDictionary : Dictionary<string, object>
+    {
+    }
+}

--- a/Sources/CouchDesignDocuments/IndexSpec.cs
+++ b/Sources/CouchDesignDocuments/IndexSpec.cs
@@ -8,12 +8,20 @@ namespace TheDmi.CouchDesignDocuments
     {
         private readonly Lazy<string> _indexFunction;
 
-        internal IndexSpec(Lazy<string> indexFunction)
+        internal IndexSpec(Lazy<string> indexFunction, dynamic analyzer)
         {
             _indexFunction = indexFunction;
+            Analyzer = analyzer;
         }
 
         [JsonProperty(PropertyName = "index")]
         public string Map => _indexFunction.Value;
+
+        public dynamic Analyzer { get; }
+
+        public bool ShouldSerializeAnalyzer()
+        {
+            return (Analyzer != null);
+        }
     }
 }

--- a/Sources/CouchDesignDocuments/IndexesSection.cs
+++ b/Sources/CouchDesignDocuments/IndexesSection.cs
@@ -7,10 +7,10 @@ namespace TheDmi.CouchDesignDocuments
 
     public abstract class IndexesSection<TSelf> : IIndexesSection
     {
-        protected static IndexSpec Index([CallerMemberName] string indexName = null)
+        protected static IndexSpec Index([CallerMemberName] string indexName = null, dynamic analyzer = null)
         {
             return new IndexSpec(
-                new Lazy<string>(() => ReadJsFromResources(indexName, typeof(TSelf))));
+                new Lazy<string>(() => ReadJsFromResources(indexName, typeof(TSelf))), analyzer);
         }
 
         private static string ReadJsFromResources(string baseName, Type viewsType)

--- a/Sources/Test/Example/ExampleDesignDocumentGenericAnalyzer.cs
+++ b/Sources/Test/Example/ExampleDesignDocumentGenericAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿namespace TheDmi.CouchDesignDocuments.Test.Example
+{
+    using TheDmi.CouchDesignDocuments;
+
+    public class ExampleDesignDocumentGenericAnalyzer : DesignDocument
+    {
+        public override string Name => "exampleWithGenericAnalyzer";
+
+        public class Indexes : IndexesSection<Indexes>
+        {
+            public static IndexSpec MyIndex => Index(analyzer: "simple");
+        }
+    }
+}

--- a/Sources/Test/Example/ExampleDesignDocumentPerfieldAnalyzer.cs
+++ b/Sources/Test/Example/ExampleDesignDocumentPerfieldAnalyzer.cs
@@ -1,0 +1,34 @@
+﻿namespace TheDmi.CouchDesignDocuments.Test.Example
+{
+    using TheDmi.CouchDesignDocuments;
+
+    public class ExampleDesignDocumentPerfieldAnalyzer : DesignDocument
+    {
+        public override string Name => "exampleWithPerfieldAnalyzer";
+
+        public class Indexes : IndexesSection<Indexes>
+        {
+            public static IndexSpec MyIndex =>
+                Index(
+                    analyzer: new AnalyzerDictionary()
+                              {
+                                  { "name", "perfield" },
+                                  { "default", "keyword" },
+                                  {
+                                      "fields",
+                                      new AnalyzerDictionary()
+                                      {
+                                          { "CapitalizedCamelCaseField", "classic" },
+                                          { "camelCaseField", "email" },
+                                          { "Capitalized_Snake_Case", "keyword" },
+                                          { "snake_case", "simple" },
+                                          { "Capitalized-Kebab-Case", "standard" },
+                                          { "kebab-case", "whitespace" },
+                                          { "CompLetELY_ranDoM-CASE", "standard" },
+                                          { "spaced Word", "standard" }
+                                      }
+                                  }
+                              });
+        }
+    }
+}


### PR DESCRIPTION
https://docs.couchdb.org/en/master/ddocs/search.html#analyzers

Hoi Dani,

We're finding ourselves using more Lucene search indexes, and our use cases require per-field analyzer configuration so I've added the support for that here (in a backwards-compatible manner).